### PR TITLE
Use short link for default JSON file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ see my [blog post](https://boxofcables.dev/hyper-v-gallery/)
 $newValue = New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Virtualization\"  `
     -Name 'GalleryLocations' -PropertyType MultiString -Value (
     'https://raw.githubusercontent.com/sirredbeard/hyper-v-gallery/master/gallery.json',
-    'https://download.microsoft.com/download/8/6/7/8675AE2C-30CD-4E3A-834B-BF00EC32F33D/json/en-us/GalleryHyperV.JSON')
+    'https://go.microsoft.com/fwlink/?linkid=851584')
 $newValue.multistring
 ```
 

--- a/add_gallery.ps1
+++ b/add_gallery.ps1
@@ -27,7 +27,7 @@ Write-Verbose "Writing new GalleryLocations."
 $newValue = New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Virtualization\"  `
     -Name 'GalleryLocations' -PropertyType MultiString -Value (
     'https://raw.githubusercontent.com/sirredbeard/hyper-v-gallery/master/gallery.json',
-    'https://download.microsoft.com/download/8/6/7/8675AE2C-30CD-4E3A-834B-BF00EC32F33D/json/en-us/GalleryHyperV.JSON')
+    'https://go.microsoft.com/fwlink/?linkid=851584')
 $newValue.multistring
 
 $newValue.multistring


### PR DESCRIPTION
The short link is useful for future usage. The underlying link may change in future (somewhat from experience). The link can be validated with `curl --head ` command.